### PR TITLE
Debian 13 ld.gold

### DIFF
--- a/install-dependencies-linux
+++ b/install-dependencies-linux
@@ -70,7 +70,13 @@ install_debian()
 	sudo apt -y install curl
 	sudo apt -y install libtcmalloc-minimal4
 	sudo apt -y install zenity
-	
+
+# GSS, 17-Feb-26: ld.gold linker deprecated with later versions of debian; package only appears to be available if needed
+    AptSearch=$(apt-cache policy binutils-gold)
+    if [[ ! "$AptSearch" == *"Candidate: (none)"* ]]; then
+      sudo apt install -y binutils-gold
+    fi
+
     echo "-------"
     echo "Done..."
 }


### PR DESCRIPTION
# Debian 13 ld.gold

## What

Task ID: **_[Update tools-scripts/install-dependencies-linux for aarch64 Debian 13](https://kinnami.atlassian.net/browse/RP-212)_**

This pull request installs apt package binutils-gold on Debian OS versions where available.

## Why

ld.gold is now considered deprecated due to a lack of maintenance for variations of Debian OS  later than version 12.
https://lwn.net/Articles/1007541/

## How

Script install-dependencies-linux checks to see if apt package binutils-gold is available.  If so, it is installed.

Test on any variation of Debian 13 OS.  If any binutils-gold packages are installed, uninstall them.  Run script install-dependencies-linux and then check to see if binutils-gold packages are installed and /usr/bin/ld.gold exists.  Running the script on any variation of Debian OS earlier than version 13 should still show /usr/bin/ld.gold exists, without installing package binutils-gold.

### Change details

- Modified script install-dependencies-linux


## Missed anything?

- [x] Explain the purpose of this PR
- [x] Self reviewed the PR
- [x] Informed of breaking changes, testing and migrations (if applicable)
- [] Updated documentation (if applicable)
- [] Attatched screenshots (if applicable)